### PR TITLE
Partprob

### DIFF
--- a/For The Motherlode.gmx/For The Motherlode.project.gmx
+++ b/For The Motherlode.gmx/For The Motherlode.project.gmx
@@ -135,6 +135,7 @@
       <script>scripts\blood_hit.gml</script>
       <script>scripts\shake_screen.gml</script>
       <script>scripts\draw_blood.gml</script>
+      <script>scripts\draw_annulus.gml</script>
     </scripts>
     <script>scripts\huder_SmoothNoise.gml</script>
   </scripts>

--- a/For The Motherlode.gmx/extensions/Smooth Noise Generator.extension.gmx
+++ b/For The Motherlode.gmx/extensions/Smooth Noise Generator.extension.gmx
@@ -3,7 +3,7 @@
   <name>Smooth Noise Generator</name>
   <version>1.0.1</version>
   <packageID>com.huder.smoothnoise</packageID>
-  <ProductID>0746C2EC14A9DFBB6BA2A516CAE885C4</ProductID>
+  <ProductID></ProductID>
   <date>27/02/16</date>
   <license>Free to use, also for commercial games.</license>
   <description></description>

--- a/For The Motherlode.gmx/objects/o_bullet.object.gmx
+++ b/For The Motherlode.gmx/objects/o_bullet.object.gmx
@@ -25,13 +25,10 @@
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>///Create trail shadow
+            <string>/// Attributes
 
-trail_shadow = instance_create(
-    x + lengthdir_x(20, 270), 
-    y + lengthdir_y(20, 270), 
-    o_bullet_trail_shadow
-);
+force = 0;
+enemy_collision = false;
 </string>
           </argument>
         </arguments>
@@ -52,9 +49,13 @@ trail_shadow = instance_create(
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>/// Attributes
+            <string>///Create trail shadow
 
-force = 0;
+trail_shadow = instance_create(
+    x + lengthdir_x(5, 270), 
+    y + lengthdir_y(5, 270), 
+    o_bullet_trail_shadow
+);
 </string>
           </argument>
         </arguments>
@@ -108,16 +109,19 @@ with (trail_shadow) {
 
 var enemy = collision_line(xprevious, yprevious, x, y, o_enemy, false, true)
 if (enemy) {
+    enemy_collision = true;
     var xx = x + lengthdir_x(distance_to_object(enemy), direction - 180);
     var yy = y + lengthdir_y(distance_to_object(enemy), direction - 180);
     while (place_meeting(xx, yy, enemy)) {
         xx += lengthdir_x(1, direction - 180);
         yy += lengthdir_y(1, direction - 180);
     }
+    x = xx;
+    y = yy;
     blood_hit(xx, yy, 30, enemy.blood_emitter.p_emitter, enemy.blood_emitter.p_type);
     enemy.hhealth -= 5;
-    if (enemy.hhealth &gt; 0) {
-        audio_play_sound(snd_blood_hit, 0, 0);
+    if (enemy.hhealth &gt; 0) {  // play death sound otherwise
+        audio_play_sound_at(snd_blood_hit, xx, yy, 0, 0, 0, 0, false, 0);
         audio_sound_pitch(snd_blood_hit, random_range(0.8, 1));
     }
     enemy.proj_pushback = force;
@@ -221,9 +225,8 @@ instance_destroy();
             <string>/// Blood on Collision
 // this calls destructor, must happen first
 
-var enemy = collision_line(xprevious, yprevious, x, y, o_enemy, true, true)
-if (enemy) {
-    draw_blood(enemy.x, enemy.y);
+if (enemy_collision) {
+    draw_blood(x, y);
     instance_destroy();
 }
 </string>
@@ -249,7 +252,10 @@ if (enemy) {
             <string>/// Self, Trail, &amp; Shadow
 
 draw_sprite_shadow(270, 5, 1, c_black, 0.2);
-draw_trail(10, 2, c_white, -1, true, 0.5);
+//draw_trail(10, 4, c_orange, -1, true, 1);
+//draw_trail(10, 3, c_yellow, -1, true, 1);
+draw_trail(10, 2, c_white, -1, true, 1);
+// mess with colors and trail size for different bullet effects
 draw_self();
 </string>
           </argument>

--- a/For The Motherlode.gmx/objects/o_bullet.object.gmx
+++ b/For The Motherlode.gmx/objects/o_bullet.object.gmx
@@ -154,6 +154,33 @@ trail_shadow.y = y + lengthdir_y(5, 270);
           </argument>
         </arguments>
       </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// Destroy if past 1/2 room size outside room
+if (x &lt; -room_width/2 ||
+    x &gt; room_width * 1.5 ||
+    y &lt; -room_height/2 ||
+    y &gt; room_height * 1.5) {
+    instance_destroy();    
+}
+</string>
+          </argument>
+        </arguments>
+      </action>
     </event>
     <event eventtype="3" enumb="0">
       <action>
@@ -175,31 +202,6 @@ trail_shadow.y = y + lengthdir_y(5, 270);
             <string>/// Orientation
 
 image_angle = direction;
-</string>
-          </argument>
-        </arguments>
-      </action>
-    </event>
-    <event eventtype="7" enumb="0">
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>/// Destroy
-
-instance_destroy();
 </string>
           </argument>
         </arguments>
@@ -252,10 +254,11 @@ if (enemy_collision) {
             <string>/// Self, Trail, &amp; Shadow
 
 draw_sprite_shadow(270, 5, 1, c_black, 0.2);
-//draw_trail(10, 4, c_orange, -1, true, 1);
-//draw_trail(10, 3, c_yellow, -1, true, 1);
+draw_trail(20, 4, c_orange, -1, true, 1);
+draw_trail(10, 3, c_yellow, -1, true, 1);
 draw_trail(10, 2, c_white, -1, true, 1);
-// mess with colors and trail size for different bullet effects
+// mess with colors, alpha, and trail length for different bullet effects
+// AND KEEP TRACK OF SHADOW!
 draw_self();
 </string>
           </argument>

--- a/For The Motherlode.gmx/objects/o_bullet_trail_shadow.object.gmx
+++ b/For The Motherlode.gmx/objects/o_bullet_trail_shadow.object.gmx
@@ -27,7 +27,7 @@
             <kind>1</kind>
             <string>/// Trail
 
-draw_trail(10, 2, c_black, -1, true, 0.1);
+draw_trail(10, 4, c_black, -1, true, 0.1);
 </string>
           </argument>
         </arguments>

--- a/For The Motherlode.gmx/objects/o_crosshair.object.gmx
+++ b/For The Motherlode.gmx/objects/o_crosshair.object.gmx
@@ -76,6 +76,14 @@ y = mouse_y;
             <string>draw_set_circle_precision(64);
 draw_set_colour(c_white);
 draw_circle(x, y, 2, false);
+//draw_circle(o_player.x, o_player.y, distance_to_point(o_player.x, o_player.y), true);
+
+if (o_player.w_current[WPN.action] == WPN_ACTION.single_shot) {
+    draw_annulus(
+        x, y, 5, 8, o_player.image_angle, 
+        o_player.image_angle + 360 * ((o_player.alarm[0] + 1) / o_player.shoot_delay), 0
+    );
+}
 </string>
           </argument>
         </arguments>

--- a/For The Motherlode.gmx/objects/o_enemy.object.gmx
+++ b/For The Motherlode.gmx/objects/o_enemy.object.gmx
@@ -26,8 +26,7 @@
           <argument>
             <kind>1</kind>
             <string>sprite_index = s_mask_human;
-blood_p_emitter = part_emitter_create(global.p_sys);
-blood_p_type = part_type_create();
+blood_emitter = instance_create(x, y, o_particle_emitter);
 
 hhealth = 99999999;
 

--- a/For The Motherlode.gmx/objects/o_handler.object.gmx
+++ b/For The Motherlode.gmx/objects/o_handler.object.gmx
@@ -33,6 +33,8 @@ instance_create(mouse_x, mouse_y, o_crosshair);
 instance_create(0, 0, o_camera);
 instance_create(room_width/2, room_height/2, o_motherlode);
 
+instance_create(room_width/2, room_height/2, o_enemy);
+/*
 repeat(10)
     instance_create(random(room_width), random(room_height), o_stabber);
 

--- a/For The Motherlode.gmx/objects/o_handler.object.gmx
+++ b/For The Motherlode.gmx/objects/o_handler.object.gmx
@@ -33,8 +33,8 @@ instance_create(mouse_x, mouse_y, o_crosshair);
 instance_create(0, 0, o_camera);
 instance_create(room_width/2, room_height/2, o_motherlode);
 
-instance_create(room_width/2, room_height/2, o_enemy);
-/*
+//instance_create(room_width/2, room_height/2, o_enemy);
+
 repeat(10)
     instance_create(random(room_width), random(room_height), o_stabber);
 

--- a/For The Motherlode.gmx/objects/o_player.object.gmx
+++ b/For The Motherlode.gmx/objects/o_player.object.gmx
@@ -39,6 +39,10 @@ shoot_delay = 6;
 muzzle_flash_p_emitter = part_emitter_create(global.p_sys);
 muzzle_flash_p_type = part_type_create();
 
+// Audio
+audio_listener_position(x, y, 0);
+audio_listener_orientation(0,1,0,0,0,1);
+
 // Bindings
 key_up = ord("W");
 key_down = ord("S");
@@ -49,10 +53,11 @@ mb_shoot = mb_left;
 
 // Sprite (Body)
 s_torso_current = s_torso_wpn;
-walk_wave_t = 0;
-walk_wave_inc = 15;
 s_feet_image_index = 0;
 s_feet_image_xscale = 1;
+walk_wave_t = 0;
+walk_wave_inc = 4;
+drawn_footprint = false;
 
 // Weapon
 base_dist_1h = 17;// pixel distance from torso sprite center to weapon sprite center
@@ -95,6 +100,30 @@ part_type_destroy(muzzle_flash_p_type);
         </arguments>
       </action>
     </event>
+    <event eventtype="2" enumb="1">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// drawn_footprint = true
+drawn_footprint = false;
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
     <event eventtype="2" enumb="0">
       <action>
         <libid>1</libid>
@@ -113,7 +142,6 @@ part_type_destroy(muzzle_flash_p_type);
           <argument>
             <kind>1</kind>
             <string>/// can_shoot = true
-
 can_shoot = true;
 </string>
           </argument>
@@ -156,10 +184,10 @@ switch (w_current[WPN.action]) {
 }
 */
 
-var spread = 5;
+var spread = 1;
 if (mouse_check_button(mb_shoot) &amp;&amp; can_shoot) {
-    audio_play_sound(w_current[WPN.sound_fire], 0, 0);
-    audio_sound_pitch(w_current[WPN.sound_fire], random_range(0.8, 1));
+    audio_play_sound(w_current[WPN.sound_fire], 0, false);
+    audio_sound_pitch(w_current[WPN.sound_fire], random_range(0.9, 1.1));
     //repeat(5) {
         with(
             instance_create(
@@ -168,8 +196,9 @@ if (mouse_check_button(mb_shoot) &amp;&amp; can_shoot) {
                 o_bullet
             )
         ) {
-            speed = 50 + random_range(-3, 3);  // WPN.proj_speed (missiles have acceleration though)
+            speed = 50;// + random_range(-3, 3);  // WPN.proj_speed (missiles have acceleration though)
             direction = other.image_angle + random_range(-spread/2, spread/2); // WPN.spread
+            image_angle = direction;
             // damage = wpn_current[WPN.damage];
             force = other.w_current[WPN.proj_force];
         }
@@ -223,6 +252,9 @@ if (mouse_check_button(mb_shoot) &amp;&amp; can_shoot) {
             <kind>1</kind>
             <string>/// Movement
 
+// Audio
+audio_listener_position(x, y, 0);
+
 // Orientation
 image_angle = point_direction(x, y, o_crosshair.x, o_crosshair.y);
 
@@ -268,17 +300,19 @@ else if (!move_right &amp;&amp; !move_left) {
 var amplitude = sprite_get_number(s_feet) - 0.9;
 var wave_val = amplitude * sin(degtorad(walk_wave_t));
 s_feet_image_index = abs(wave_val);
+// set image x-scale
 if (wave_val &lt; 0) {
     s_feet_image_xscale = -1;
 }
 else {
     s_feet_image_xscale = 1;
 }
-
+// animate
 if (move_up || move_down || move_left || move_right) {
-    walk_wave_t += walk_wave_inc; 
+    walk_wave_t += walk_wave_inc * speed; 
 }
 else {
+    // smoothly return to first image index (walk_wave_t = 0 ~ wave_val = 0);
     if (abs(wave_val) &gt; 0.1) {
         if (abs(wave_val) &lt; abs(amplitude * sin(degtorad(walk_wave_t + 1)))) {
             walk_wave_t -= walk_wave_inc;
@@ -526,10 +560,14 @@ draw_set_alpha(1);
           <argument>
             <kind>1</kind>
             <string>/// Footprints
-if (s_feet_image_index &gt;= sprite_get_number(s_feet) - 1) {
+
+// script too
+if (!drawn_footprint &amp;&amp; round(s_feet_image_index) == sprite_get_number(s_feet) - 1) {
     surface_set_target(global.surf);
-    draw_sprite_ext(s_footprint, 0, x, y, 1, s_feet_image_xscale, direction, c_white, 0.4);
-    surface_reset_target();   
+    draw_sprite_ext(s_footprint, 0, x, y, 1, s_feet_image_xscale, direction, c_white, 0.3);
+    surface_reset_target();
+    drawn_footprint = true;
+    alarm[1] = walk_wave_inc * 2;
 }
 </string>
           </argument>

--- a/For The Motherlode.gmx/objects/o_player.object.gmx
+++ b/For The Motherlode.gmx/objects/o_player.object.gmx
@@ -184,7 +184,7 @@ switch (w_current[WPN.action]) {
 }
 */
 
-var spread = 1;
+var spread = 0;
 if (mouse_check_button(mb_shoot) &amp;&amp; can_shoot) {
     audio_play_sound(w_current[WPN.sound_fire], 0, false);
     audio_sound_pitch(w_current[WPN.sound_fire], random_range(0.9, 1.1));

--- a/For The Motherlode.gmx/objects/o_stabber.object.gmx
+++ b/For The Motherlode.gmx/objects/o_stabber.object.gmx
@@ -39,6 +39,7 @@ strafe_dir_time = 0;
 // Stab stuff
 can_stab = true;
 stab_time = 0;
+stab_speed = 10;
 has_stabbed = false;
 x_stab = x + lengthdir_x(20, image_angle);
 y_stab = y + lengthdir_y(20, image_angle);
@@ -184,7 +185,7 @@ else {
     if (can_stab) {
         torso_y_scale = choose(1, -1);
         stab_time = 10;
-        speed = random_range(5, 10); // stab_speed
+        speed = stab_speed;
         can_stab = false;
         has_stabbed = false;
         alarm[0] = random_range(20, 30);
@@ -250,8 +251,8 @@ x_stab = x + lengthdir_x(20, image_angle);
 y_stab = y + lengthdir_y(20, image_angle);
 
 if (!has_stabbed &amp;&amp; collision_point(x_stab, y_stab, o_player, true, false)) {
-    audio_play_sound(snd_stab, 0, 0);
-    audio_sound_pitch(snd_stab, random_range(0.8, 1));
+    audio_play_sound(snd_stab, 0, false);
+    audio_sound_pitch(snd_stab, random_range(0.9, 1.2));
     blood_hit(x_stab, y_stab, 30, stab_p_emitter, stab_p_type);
     shake_screen(10, 10);
     has_stabbed = true;
@@ -298,7 +299,7 @@ if (total_health &lt;= 0) {
             // Explode from center: (360 / num_giblets) * (i + 1);
         }
     }
-    audio_play_sound(snd_blood_splat, 1, 0);
+    audio_play_sound_at(snd_blood_splat, x, y, 0, 0, 0, 0, false, 1);
     audio_sound_pitch(snd_blood_splat, random_range(0.8, 1));
     blood_hit(x, y, 100, blood_emitter.p_emitter, blood_emitter.p_type);
     // Set alarm for particle emitter / type destruction (1 second)

--- a/For The Motherlode.gmx/rooms/room0.room.gmx
+++ b/For The Motherlode.gmx/rooms/room0.room.gmx
@@ -52,6 +52,7 @@
   </views>
   <instances>
     <instance objName="o_handler" x="0" y="0" name="inst_76C43CF6" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
+    <instance objName="o_globals" x="96" y="256" name="inst_E0AC5A63" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>

--- a/For The Motherlode.gmx/rooms/room0.room.gmx
+++ b/For The Motherlode.gmx/rooms/room0.room.gmx
@@ -52,7 +52,6 @@
   </views>
   <instances>
     <instance objName="o_handler" x="0" y="0" name="inst_76C43CF6" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
-    <instance objName="o_globals" x="96" y="256" name="inst_E0AC5A63" locked="0" code="" scaleX="1" scaleY="1" colour="4294967295" rotation="0"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>

--- a/For The Motherlode.gmx/scripts/draw_annulus.gml
+++ b/For The Motherlode.gmx/scripts/draw_annulus.gml
@@ -1,0 +1,32 @@
+///draw_annulus(x, y, inner_radius, outer_radius, startangle, endangle[, precision]) */
+var cx, cy, irad, orad, prec, dir, inout, rad, theta1, theta1;
+
+/* Just grab the arguments */
+cx=argument0;
+cy=argument1;
+irad=argument2;
+orad=argument3;
+theta1=min(argument4, argument5);
+theta2=max(argument4, argument5);
+prec=argument6;
+if (prec<=0) { prec=0.5; }
+
+/* Draw the annulus */
+draw_primitive_begin(pr_trianglestrip);
+
+var center_offset = 1;  // added by me with no idea why it is necessary
+for ({dir=theta1; inout=0}; dir<=theta2; {dir+=prec; inout++}) {
+  if (inout % 2) {
+    draw_vertex(cx + center_offset + lengthdir_x(irad, dir), cy + center_offset + lengthdir_y(irad, dir));
+  }
+  else {
+    draw_vertex(cx + center_offset + lengthdir_x(orad, dir), cy + center_offset + lengthdir_y(orad, dir));
+  }
+}
+
+/* This just makes sure it always ends on the inner ring so it doesn't leave gaps. */
+if (inout % 2) {
+  draw_vertex(cx + lengthdir_x(irad, dir), cy + lengthdir_y(irad, dir));
+}
+
+draw_primitive_end();

--- a/For The Motherlode.gmx/scripts/draw_circle_part.gml
+++ b/For The Motherlode.gmx/scripts/draw_circle_part.gml
@@ -1,0 +1,20 @@
+/* draw_circle_part(x,y,r,ang,off,outline) */
+var X,Y,r,ang,off,outline,i;
+i=0;
+X=argument0; //x position
+Y=argument1; //y position
+r=argument2; // radius
+ang=argument3; // angle of the circle drawn
+off=argument4; // offset angle to draw the part
+outline=argument5; // whether to only draw an outline T/F 
+if!(outline){
+draw_primitive_begin(pr_trianglefan);
+draw_vertex(X,Y);
+} else
+draw_primitive_begin(pr_linestrip);
+draw_vertex(X+lengthdir_x(r,off),Y+lengthdir_y(r,off));
+repeat(abs(ang)mod 360){
+draw_vertex(X+lengthdir_x(r,i+off),Y+lengthdir_y(r,i+off));
+i+=1*sign(ang);
+}
+draw_primitive_end();


### PR DESCRIPTION
Particles were not appearing unless new emitters (using global.p_sys) were created. This occurred due to a duplicate instance of o_globals, one created via the room editor.

Included in this PR
- Better bullet tracer effects (multiple trails)
- Fixed footprint drawing (which must be extended to NPCs)
- A shoot delay indicator
- Localized sound
- Fixed projectile collisions
